### PR TITLE
gotest-annotations: don't only post annotations for _test.go files

### DIFF
--- a/.github/actions/gotest-annotations/action.yml
+++ b/.github/actions/gotest-annotations/action.yml
@@ -22,7 +22,7 @@ runs:
       with:
         script: |
           const lineReader = require('line-by-line');
-          const testRegex = /(\s*[\w\d]+_test.go:\d+:)(.*?)(---\sFAIL:.*)/gs;
+          const testRegex = /(\s*[\w\d]+.go:\d+:)(.*?)(---\sFAIL:.*)/gs;
           let tests = {};
           const globber = await glob.create(`${{ inputs.directory }}/**/*.json`);
           for await (const jsonReport of globber.globGenerator()) {
@@ -48,7 +48,7 @@ runs:
             });
             lr.on('end', function() {
               for (const [key, test] of Object.entries(tests)) {
-                if (!test.output.includes("FAIL") || !test.output.includes("_test.go")) {
+                if (!test.output.includes("FAIL") || !test.output.includes(".go")) {
                   continue;
                 }
                 var result;


### PR DESCRIPTION
In the context of https://github.com/docker/buildx/pull/1770, I discovered that only files that end in `_test.go` are detected for annotations. This meant annotations weren't posted because the names of the test files reflected the name of the commands file, e.g. so `tests/build.go` tested `commands/build.go`.

Ideally, we should post annotations no matter which file the failure occurs in, which could also occur if a test helper failed which was not in a `_test.go` file.