### PR TITLE
release-json: remove releases output

### DIFF
--- a/.github/workflows/releases-json.yml
+++ b/.github/workflows/releases-json.yml
@@ -14,10 +14,6 @@ on:
         required: false
         type: string
         default: 'releases.json'
-    outputs:
-      releases:
-        description: GitHub Releases JSON
-        value: ${{ jobs.generate.outputs.releases }}
 
 jobs:
   generate:
@@ -62,7 +58,6 @@ jobs:
               };
             }
 
-            core.setOutput('releases', JSON.stringify(res));
             await fs.writeFileSync('${{ inputs.filename }}', JSON.stringify(res, null, 2));
       -
         name: Check file


### PR DESCRIPTION
related to https://github.com/crazy-max/ghaction-hugo/actions/runs/6050726305

![image](https://github.com/crazy-max/.github/assets/1951866/75472404-240a-4718-9509-8ed2e3179328)

Looks like actions output value is limited :cry: