### PR TITLE
release-json: handle edge release

### DIFF
--- a/.github/workflows/releases-json.yml
+++ b/.github/workflows/releases-json.yml
@@ -22,6 +22,14 @@ jobs:
       releases: ${{ steps.generate.outputs.releases }}
     steps:
       -
+        name: Install npm deps
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await core.group(`Install npm deps`, async () => {
+              await exec.exec('npm', ['install', 'semver']);
+            });
+      -
         name: Generate
         id: generate
         uses: actions/github-script@v7
@@ -29,6 +37,7 @@ jobs:
           retries: 3
           script: |
             const fs = require('fs');
+            const semver = require('semver');
 
             let res = {};
             const [owner, repo] = '${{ inputs.repository }}'.split('/');
@@ -50,6 +59,21 @@ jobs:
               repo,
             }));
             for (const release of releases) {
+              if (release.draft) {
+                continue;
+              }
+              if (!res['edge'] && release.prerelease) {
+                if (semver.gt(release.tag_name, res['latest'].tag_name)) {
+                  res['edge'] = {
+                    id: release.id,
+                    tag_name: release.tag_name,
+                    html_url: release.html_url,
+                    assets: release.assets.map(asset => asset.browser_download_url).sort(),
+                  };
+                } else {
+                  res['edge'] = res['latest'];
+                }
+              }
               res[release.tag_name] = {
                 id: release.id,
                 tag_name: release.tag_name,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,30 @@ jobs:
         run: |
           jq . buildx-releases.json
 
+  releases-json-edge:
+    uses: ./.github/workflows/releases-json.yml
+    with:
+      repository: crazy-max/releases-json-test
+      artifact_name: test-edge-releases-json
+      filename: test-edge-releases.json
+    secrets: inherit
+
+  releases-json-edge-check:
+    runs-on: ubuntu-latest
+    needs:
+      - releases-json-edge
+    steps:
+      -
+        name: Download
+        uses: actions/download-artifact@v4
+        with:
+          name: test-edge-releases-json
+          path: .
+      -
+        name: Check file
+        run: |
+          jq . test-edge-releases.json
+
   install-k3s:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
follow-up https://github.com/moby/moby/pull/48964#discussion_r1860371031

creates `edge` entry in releases json file: https://github.com/crazy-max/.github/actions/runs/12048783446/job/33594144826#step:3:12

```json
{
  "latest": {
    "id": 187790691,
    "tag_name": "v0.1.0",
    "html_url": "https://github.com/crazy-max/releases-json-test/releases/tag/v0.1.0",
    "assets": []
  },
  "edge": {
    "id": 187790864,
    "tag_name": "v0.2.0-rc1",
    "html_url": "https://github.com/crazy-max/releases-json-test/releases/tag/v0.2.0-rc1",
    "assets": []
  },
  "v0.2.0-rc1": {
    "id": 187790864,
    "tag_name": "v0.2.0-rc1",
    "html_url": "https://github.com/crazy-max/releases-json-test/releases/tag/v0.2.0-rc1",
    "assets": []
  },
  "v0.1.0": {
    "id": 187790691,
    "tag_name": "v0.1.0",
    "html_url": "https://github.com/crazy-max/releases-json-test/releases/tag/v0.1.0",
    "assets": []
  }
}
```