### PR TITLE
pr-author-assign: don't check if author can be assigned

### DIFF
--- a/.github/workflows/pr-assign-author.yml
+++ b/.github/workflows/pr-assign-author.yml
@@ -32,16 +32,6 @@ jobs:
                 throw new Error(`Not a user, skipping.`);
               }
 
-              const respCheck = await github.rest.issues.checkUserCanBeAssignedToIssue({
-                ...context.repo,
-                issue_number: number,
-                assignee: author
-              });
-              core.debug(`checkUserCanBeAssignedToIssue resp: ${JSON.stringify(respCheck, null, 2)}`);
-              if (respCheck.status !== 204) {
-                throw new Error(`Cannot assign @${author} to the pull request #${number}, skipping.`);
-              }
-
               const respAdd = await github.rest.issues.addAssignees({
                 ...context.repo,
                 issue_number: number,


### PR DESCRIPTION
Seems this check is not accurate and fails to find users in large organizations on some repos: https://github.com/docker/buildx/actions/runs/14520766131/job/40740903158#step:2:50

```
RequestError [HttpError]: User cannot be assigned to this issue.
Error: Unhandled error: HttpError: User cannot be assigned to this issue.
    at /home/runner/work/_actions/actions/github-script/v7/dist/index.js:9537:21
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:18:19)
    at async main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:20) {
  status: 404,
  response: {
    url: 'https://api.github.com/repos/docker/buildx/issues/3126/assignees/jsternberg',
    status: 404,
    headers: {
      'access-control-allow-origin': '*',
      'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset',
      'content-encoding': 'gzip',
      'content-security-policy': "default-src 'none'",
      'content-type': 'application/json; charset=utf-8',
      date: 'Thu, 17 Apr 2025 16:54:23 GMT',
      'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
      server: 'github.com',
      'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
      'transfer-encoding': 'chunked',
      vary: 'Accept-Encoding, Accept, X-Requested-With',
      'x-accepted-github-permissions': 'issues=read; pull_requests=read',
      'x-content-type-options': 'nosniff',
      'x-frame-options': 'deny',
      'x-github-api-version-selected': '2022-11-28',
      'x-github-media-type': 'github.v3; format=json',
      'x-github-request-id': '9401:3690E0:C64616:CC4F94:6801323F',
      'x-ratelimit-limit': '15000',
      'x-ratelimit-remaining': '14999',
      'x-ratelimit-reset': '1744912463',
      'x-ratelimit-resource': 'core',
      'x-ratelimit-used': '1',
      'x-xss-protection': '0'
    },
    data: {
      message: 'User cannot be assigned to this issue.',
      documentation_url: 'https://docs.github.com/rest/issues/assignees#check-if-a-user-can-be-assigned-to-a-issue',
      status: '404'
    }
  },
  request: {
    method: 'GET',
    url: 'https://api.github.com/repos/docker/buildx/issues/3126/assignees/jsternberg',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'actions/github-script octokit-core.js/5.0.1 Node.js/20.19.0 (linux; x64)',
      authorization: 'token [REDACTED]'
    },
    request: {
      agent: [Agent],
      fetch: [Function: proxyFetch],
      hook: [Function: bound bound register]
    }
  }
}
```

Even though this user is a maintainer https://api.github.com/repos/docker/buildx/issues/3126/assignees/jsternberg

Looks similar to https://github.com/cli/cli/issues/6235